### PR TITLE
Add max-width container for hero image on desktop

### DIFF
--- a/src/templates/index.tsx
+++ b/src/templates/index.tsx
@@ -69,6 +69,28 @@ export const SiteMain = css`
   }
 `;
 
+const HeroImageContainer = styled.div`
+  flex-grow: 3;
+  margin-top: 2rem;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-color: ${bgColor.primary};
+  
+  @media (min-width: 1024px) {
+    padding: 2rem;
+    
+    .hero-image-wrapper {
+      max-width: 1200px;
+      width: 100%;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.3);
+    }
+  }
+`;
+
 export const Meta = (props: IndexProps) => {
   const imageData = props.data.header.childImageSharp.gatsbyImageData;
   const { width, height } = imageData.images.fallback!;
@@ -241,13 +263,16 @@ const IndexPage: React.FC<IndexProps> = props => {
             </div> */}
           </div>
         </main>
-        <StaticImage
-          src="../content/img/beach_cropped.jpg"
-          alt="homepage beach background"
-          placeholder="blurred"
-          css={css`flex-grow: 3;margin-top: 2rem;`}
-        // height={600}
-        />
+        <HeroImageContainer>
+          <div className="hero-image-wrapper">
+            <StaticImage
+              src="../content/img/beach_cropped.jpg"
+              alt="homepage beach background"
+              placeholder="blurred"
+              css={css`width: 100%; height: 100%;`}
+            />
+          </div>
+        </HeroImageContainer>
         <Footer />
       </Wrapper>
     </IndexLayout >


### PR DESCRIPTION
## Summary
- Adds a styled container that limits the hero image width on desktop screens
- Creates a more polished, card-like appearance for the beach image on larger screens
- Maintains full-width display on mobile for better user experience

## Changes
- Created `HeroImageContainer` styled component
- Set max-width of 1200px for desktop screens (>= 1024px)
- Added rounded corners and box shadow for desktop view
- Wrapped the `StaticImage` component in the new container

## Visual Changes
Desktop:
- Hero image now has a maximum width instead of spanning the full screen
- Rounded corners and subtle shadow create a card-like appearance
- Better visual balance with the content above

Mobile:
- No changes - image remains full width

🤖 Generated with [Claude Code](https://claude.ai/code)